### PR TITLE
:recycle: Create the Creator interface

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -79,3 +79,27 @@ func (conn *BaseConnection) BeginTx(ctx context.Context, opts *sql.TxOptions) (*
 	}
 	return NewTx(tx), nil
 }
+
+func (conn *BaseConnection) Exec(query string, args ...interface{}) (sql.Result, error) {
+	return conn._db.Exec(query, args...)
+}
+
+func (conn *BaseConnection) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return conn._db.ExecContext(ctx, query, args)
+}
+
+func (conn *BaseConnection) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	return conn._db.Query(query, args)
+}
+
+func (conn *BaseConnection) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return conn._db.QueryContext(ctx, query, args)
+}
+
+func (conn *BaseConnection) Prepare(query string) (*sql.Stmt, error) {
+	return conn._db.Prepare(query)
+}
+
+func (conn *BaseConnection) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return conn._db.PrepareContext(ctx, query)
+}

--- a/generator/tpl/connections.go
+++ b/generator/tpl/connections.go
@@ -38,7 +38,7 @@ func RenderConnections(_buffer io.StringWriter, connections []*generatorModels.C
 		_buffer.WriteString(gorazor.HTMLEscape(Pointer))
 		_buffer.WriteString(gorazor.HTMLEscape(model.StoreName()))
 	}
-	_buffer.WriteString("\n}\n\ntype Connection interface {\n\tceous.Connection\n\tCreator\n}")
+	_buffer.WriteString("\n}\n\ntype Connection interface {\n\tceous.DBRunner\n\tCreator\n}")
 	for _, conn := range connections {
 		_buffer.WriteString("\ntype ")
 		_buffer.WriteString(gorazor.HTMLEscape(conn.ConnectionName()))

--- a/generator/tpl/connections.go
+++ b/generator/tpl/connections.go
@@ -21,7 +21,7 @@ func Connections(connections []*generatorModels.Connection, models []*generatorM
 
 // RenderConnections render tpl/connections.gohtml
 func RenderConnections(_buffer io.StringWriter, connections []*generatorModels.Connection, models []*generatorModels.Model) {
-	_buffer.WriteString("\n\ntype Connection interface {\n\tceous.Connection")
+	_buffer.WriteString("\n\ntype Creator interface {")
 	for _, model := range models {
 		_buffer.WriteString("\n\t// ")
 		_buffer.WriteString(gorazor.HTMLEscape(model.Name))
@@ -38,7 +38,7 @@ func RenderConnections(_buffer io.StringWriter, connections []*generatorModels.C
 		_buffer.WriteString(gorazor.HTMLEscape(Pointer))
 		_buffer.WriteString(gorazor.HTMLEscape(model.StoreName()))
 	}
-	_buffer.WriteString("\n}")
+	_buffer.WriteString("\n}\n\ntype Connection interface {\n\tceous.Connection\n\tCreator\n}")
 	for _, conn := range connections {
 		_buffer.WriteString("\ntype ")
 		_buffer.WriteString(gorazor.HTMLEscape(conn.ConnectionName()))

--- a/generator/tpl/connections.gohtml
+++ b/generator/tpl/connections.gohtml
@@ -6,14 +6,18 @@
 	var models []*generatorModels.Model
 }
 
-type Connection interface {
-	ceous.Connection
+type Creator interface {
 @for _, model := range models {@
 	// @model.Name@:Query creates a new query related with the connection set.
 	@model.Name@:Query(options ...ceous.CeousOption) @Pointer@model.QueryName()
 	// @model.Name@:Store creates a new store related with the connection set.
 	@model.Name@:Store(options ...ceous.CeousOption) @Pointer@model.StoreName()
 }
+}
+
+type Connection interface {
+	ceous.Connection
+	Creator
 }
 
 @for _, conn := range connections {@

--- a/generator/tpl/connections.gohtml
+++ b/generator/tpl/connections.gohtml
@@ -16,7 +16,7 @@ type Creator interface {
 }
 
 type Connection interface {
-	ceous.Connection
+	ceous.DBRunner
 	Creator
 }
 

--- a/tests/db/ceous.go
+++ b/tests/db/ceous.go
@@ -30,7 +30,7 @@ type Creator interface {
 }
 
 type Connection interface {
-	ceous.Connection
+	ceous.DBRunner
 	Creator
 }
 type DefaultConnection struct {

--- a/tests/db/ceous.go
+++ b/tests/db/ceous.go
@@ -10,8 +10,7 @@ import (
 	time "time"
 )
 
-type Connection interface {
-	ceous.Connection
+type Creator interface {
 	// UserQuery creates a new query related with the connection set.
 	UserQuery(options ...ceous.CeousOption) *userQuery
 	// UserStore creates a new store related with the connection set.
@@ -28,6 +27,11 @@ type Connection interface {
 	UserIgnoredQuery(options ...ceous.CeousOption) *userIgnoredQuery
 	// UserIgnoredStore creates a new store related with the connection set.
 	UserIgnoredStore(options ...ceous.CeousOption) *userIgnoredStore
+}
+
+type Connection interface {
+	ceous.Connection
+	Creator
 }
 type DefaultConnection struct {
 	*ceous.BaseConnection


### PR DESCRIPTION
This PR creates a new generated interface: `Creator`.

Creator describes the methods for initializing queries, stores.

The old Connection still being used and now implements DBRunner.